### PR TITLE
Adds a GET to list all supported endpoints in each router.

### DIFF
--- a/infra/cray_infra/api/fastapi/routers/generate_router.py
+++ b/infra/cray_infra/api/fastapi/routers/generate_router.py
@@ -3,13 +3,19 @@ from cray_infra.api.fastapi.generate.generate import generate
 from cray_infra.api.fastapi.generate.finish_work import finish_work
 from cray_infra.api.fastapi.generate.get_results import get_results
 
-from cray_infra.api.fastapi.routers.request_types.generate_request import GenerateRequest
+from cray_infra.api.fastapi.routers.request_types.generate_request import (
+    GenerateRequest,
+)
 from cray_infra.api.fastapi.routers.request_types.get_work_request import GetWorkRequest
-from cray_infra.api.fastapi.routers.request_types.finish_work_request import FinishWorkRequests
-from cray_infra.api.fastapi.routers.request_types.get_results_request import GetResultsRequest
+from cray_infra.api.fastapi.routers.request_types.finish_work_request import (
+    FinishWorkRequests,
+)
+from cray_infra.api.fastapi.routers.request_types.get_results_request import (
+    GetResultsRequest,
+)
 
 from fastapi import APIRouter
-
+from fastapi.responses import JSONResponse
 import logging
 
 logger = logging.getLogger(__name__)
@@ -21,16 +27,26 @@ generate_router = APIRouter(prefix="/generate")
 async def generate_endpoint(request: GenerateRequest):
     return await generate(request)
 
+
 @generate_router.post("/get_results")
-async def get_results_endpoint(request : GetResultsRequest):
+async def get_results_endpoint(request: GetResultsRequest):
     return await get_results(request)
 
+
 @generate_router.post("/get_work")
-async def get_work_endpoint(request : GetWorkRequest):
+async def get_work_endpoint(request: GetWorkRequest):
     return await get_work(request)
 
+
 @generate_router.post("/finish_work")
-async def finish_work_endpoint(requests : FinishWorkRequests):
+async def finish_work_endpoint(requests: FinishWorkRequests):
     return await finish_work(requests)
 
 
+@generate_router.get("/endpoints")
+async def list_routes():
+    routes = [
+        f"Path: {route.path}, Methods: {', '.join(route.methods)}"
+        for route in generate_router.routes
+    ]
+    return JSONResponse(content={"endpoints": routes}, media_type="application/json")

--- a/infra/cray_infra/api/fastapi/routers/health_router.py
+++ b/infra/cray_infra/api/fastapi/routers/health_router.py
@@ -2,6 +2,7 @@ from cray_infra.api.fastapi.health.check_health import check_health
 
 from fastapi import APIRouter
 
+from fastapi.responses import JSONResponse
 import logging
 
 logger = logging.getLogger(__name__)
@@ -17,3 +18,12 @@ async def health():
 @health_router.get("/keepalive")
 async def health():
     return {"status": "ok"}
+
+
+@health_router.get("/endpoints")
+async def list_routes():
+    routes = [
+        f"Path: {route.path}, Methods: {', '.join(route.methods)}"
+        for route in health_router.routes
+    ]
+    return JSONResponse(content={"endpoints": routes}, media_type="application/json")

--- a/infra/cray_infra/api/fastapi/routers/megatron_router.py
+++ b/infra/cray_infra/api/fastapi/routers/megatron_router.py
@@ -12,10 +12,8 @@ from cray_infra.training.squeue import squeue
 from fastapi import APIRouter, Request, HTTPException, status
 from fastapi.responses import StreamingResponse, JSONResponse
 
-import os
-
 import traceback
-import yaml
+
 import logging
 
 logger = logging.getLogger(__name__)
@@ -41,10 +39,7 @@ async def train(request: Request):
 
     job_status = await launch_training_job(job_config)
 
-    return TrainResponse(
-        job_status=job_status,
-        job_config=job_config
-    )
+    return TrainResponse(job_status=job_status, job_config=job_config)
 
 
 @megatron_router.get("/train/{job_hash}")
@@ -69,6 +64,16 @@ async def get_training_logs(model_name: str, starting_line_number: int = 0):
 async def models():
     return await list_models()
 
+
 @megatron_router.get("/squeue")
 async def get_squeue():
     return await squeue()
+
+
+@megatron_router.get("/endpoints")
+async def list_routes():
+    routes = [
+        f"Path: {route.path}, Methods: {', '.join(route.methods)}"
+        for route in megatron_router.routes
+    ]
+    return JSONResponse(content={"endpoints": routes}, media_type="application/json")

--- a/infra/cray_infra/api/fastapi/routers/openai_router.py
+++ b/infra/cray_infra/api/fastapi/routers/openai_router.py
@@ -111,3 +111,12 @@ async def create_completion(request: CompletionRequest, raw_request: Request):
         return StreamingResponse(content=generator(), media_type="text/event-stream")
     except Exception as e:
         return JSONResponse(content={"error": str(e)}, status_code=500)
+
+
+@openai_router.get("/endpoints")
+async def list_routes():
+    routes = [
+        f"Path: {route.path}, Methods: {', '.join(route.methods)}"
+        for route in openai_router.routes
+    ]
+    return JSONResponse(content={"endpoints": routes}, media_type="application/json")


### PR DESCRIPTION
```
➜  cray git:(sudnya.list_all_endpoints) ✗ curl -X GET http://localhost:8000/v1/generate/endpoints
{"endpoints":["Path: /generate, Methods: POST","Path: /generate/get_results, Methods: POST","Path: /generate/get_work, Methods: POST","Path: /generate/finish_work, Methods: POST","Path: /generate/endpoints, Methods: GET"]}%
➜  cray git:(sudnya.list_all_endpoints) ✗ curl -X GET http://localhost:8000/v1/health/endpoints
{"endpoints":["Path: /health, Methods: GET","Path: /health/keepalive, Methods: GET","Path: /health/endpoints, Methods: GET"]}%
➜  cray git:(sudnya.list_all_endpoints) ✗ curl -X GET http://localhost:8000/v1/megatron/endpoints
{"endpoints":["Path: /megatron/train, Methods: POST","Path: /megatron/train/{job_hash}, Methods: GET","Path: /megatron/train/logs/{model_name}, Methods: GET","Path: /megatron/list_models, Methods: GET","Path: /megatron/squeue, Methods: GET","Path: /megatron/endpoints, Methods: GET"]}%
➜  cray git:(sudnya.list_all_endpoints) ✗ curl -X GET http://localhost:8000/v1/openai/endpoints
{"endpoints":["Path: /openai/tokenize, Methods: POST","Path: /openai/chat/completions, Methods: POST","Path: /openai/completions, Methods: POST","Path: /openai/endpoints, Methods: GET"]}%
```